### PR TITLE
Remove .vscode/ from repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 .env
 .cache/
 .idea/
+.vscode/
 # Local Netlify folder
 .netlify

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-    "editor.wordWrap": "on",
-    "editor.multiCursorModifier": "ctrlCmd"
-}


### PR DESCRIPTION
## Summary
- Untracked `.vscode/settings.json` from git (it contained personal editor prefs — `wordWrap` and `multiCursorModifier`)
- Added `.vscode/` to `.gitignore` so it stays out permanently

## Test plan
- [x] Confirm `.vscode/` no longer appears in `git status` after a fresh clone
- [x] Confirm local editor settings still work (folder is untouched on disk)

🤖 Generated with [Claude Code](https://claude.com/claude-code)