### PR TITLE
fix: address Lighthouse SEO, accessibility, and image delivery findings

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -113,21 +113,21 @@ export default function App() {
             <picture>
               <source srcSet="/images/01.avif" type="image/avif" />
               <source srcSet="/images/01.webp" type="image/webp" />
-              <img className="w-full aspect-[4/5] object-cover brightness-90 group-hover:brightness-100 group-hover:scale-[1.02] transition-all duration-500 ease-out" src="/images/01.jpg" alt="Bike trip around Khao Yai, Thailand" />
+              <img className="w-full aspect-[4/5] object-cover brightness-90 group-hover:brightness-100 group-hover:scale-[1.02] transition-all duration-500 ease-out" src="/images/01.jpg" alt="Bike trip around Khao Yai, Thailand" loading="lazy" />
             </picture>
           </a>
           <a className="glightbox block overflow-hidden group" href="/images/02.jpg" data-description="Me racing at Bira Circuit (Pattaya, Thailand)">
             <picture>
               <source srcSet="/images/02.avif" type="image/avif" />
               <source srcSet="/images/02.webp" type="image/webp" />
-              <img className="w-full aspect-[4/5] object-cover brightness-90 group-hover:brightness-100 group-hover:scale-[1.02] transition-all duration-500 ease-out" src="/images/02.jpg" alt="Racing at Bira Circuit, Pattaya" />
+              <img className="w-full aspect-[4/5] object-cover brightness-90 group-hover:brightness-100 group-hover:scale-[1.02] transition-all duration-500 ease-out" src="/images/02.jpg" alt="Racing at Bira Circuit, Pattaya" loading="lazy" />
             </picture>
           </a>
           <a className="glightbox block overflow-hidden group" href="/images/03.jpg" data-description="After the shower (Samut Prakan, Thailand)">
             <picture>
               <source srcSet="/images/03.avif" type="image/avif" />
               <source srcSet="/images/03.webp" type="image/webp" />
-              <img className="w-full aspect-[4/5] object-cover brightness-90 group-hover:brightness-100 group-hover:scale-[1.02] transition-all duration-500 ease-out" src="/images/03.jpg" alt="After the shower, Samut Prakan" />
+              <img className="w-full aspect-[4/5] object-cover brightness-90 group-hover:brightness-100 group-hover:scale-[1.02] transition-all duration-500 ease-out" src="/images/03.jpg" alt="After the shower, Samut Prakan" loading="lazy" />
             </picture>
           </a>
         </div>
@@ -161,6 +161,7 @@ export default function App() {
                       checked={allChecked}
                       onChange={e => toggleAll(e.target.checked)}
                       className="cursor-pointer accent-white"
+                      aria-label="Select all parts"
                     />
                   </th>
                   <th className="pb-3 pr-4 font-medium text-white/40 text-xs uppercase tracking-wider">Name</th>
@@ -186,6 +187,7 @@ export default function App() {
                           checked={record.checked}
                           onChange={() => toggleOne(record.id)}
                           className="cursor-pointer accent-white"
+                          aria-label={`Select ${record.fields.Type}`}
                         />
                       </td>
                       <td className="py-3 pr-4 text-white/90">

--- a/src/index.html
+++ b/src/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" href="/favicon.ico" type="image/x-icon" />
     <title>Yamaha MT-07 Parts</title>
+    <meta name="description" content="Aftermarket customization parts list and photo gallery for a 2017 Yamaha MT-07 based in Thailand." />
   </head>
 
   <body>


### PR DESCRIPTION
## Lighthouse Report

[lighthouse_report.pdf](https://github.com/user-attachments/files/28246236/lighthouse_report.pdf)

## Summary

- Add `<meta name="description">` — fixes SEO audit (91 → 100)
- Add `aria-label` to select-all and per-row checkboxes — fixes "Form elements do not have associated labels" accessibility audit
- Add `loading="lazy"` to all three gallery images — all are below the fold (hero takes full viewport); defers their fetch until the user scrolls down (~209 KiB savings flagged by Lighthouse)

## Test plan

- [x] Confirm meta description appears in page source
- [ ] Run Lighthouse again and verify SEO hits 100 and Accessibility improves
- [x] Scroll down to gallery — images load as expected
- [x] Checkboxes in parts table still work (select all + individual toggle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)